### PR TITLE
增加对枚举类型的识别和支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/
 /out/
 /out/production/classes/
+/.idea/

--- a/src/main/java/com/ruiyu/dart_to_helper/node/ClassGeneratorInfoModel.kt
+++ b/src/main/java/com/ruiyu/dart_to_helper/node/ClassGeneratorInfoModel.kt
@@ -20,8 +20,8 @@ class HelperClassGeneratorInfo {
     val fields: MutableList<Filed> = mutableListOf()
 
 
-    fun addFiled(type: String, name: String, isLate: Boolean, annotationValue: List<AnnotationValue>?) {
-        fields.add(Filed(type, name, isLate).apply {
+    fun addFiled(type: String, name: String, isLate: Boolean, isEnum: Boolean, annotationValue: List<AnnotationValue>?) {
+        fields.add(Filed(type, name, isLate, isEnum).apply {
             this.annotationValue = annotationValue
         })
     }
@@ -93,6 +93,9 @@ class HelperClassGeneratorInfo {
                         "\t\tdata.$name = (json['$getJsonName'] as List).map((v) => ${listSubType}().fromJson(v)).toList();\n" +
                         "\t}"
             }
+            filed.isEnum -> {
+                "if (json['$getJsonName'] != null) {\n\t\tdata.$name = ${type.replace("?","")}.values[json['$getJsonName']];\n\t}"
+            }
             else -> // class
                 "if (json['$getJsonName'] != null) {\n\t\tdata.$name = ${type.replace("?","")}().fromJson(json['$getJsonName']);\n\t}"
         }
@@ -148,6 +151,9 @@ class HelperClassGeneratorInfo {
                 // class list
                 return "data['$getJsonName'] =  $value;"
             }
+            filed.isEnum -> {
+                return "data['$getJsonName'] = ${thisKey}.index;"
+            }
             else -> {
                 // class
                 return "data['$getJsonName'] = ${thisKey}${isLateCallSymbol(filed.isLate)}toJson();"
@@ -198,7 +204,9 @@ class Filed constructor(
     //字段名字
     var name: String,
     //是否是late修饰
-    var isLate: Boolean
+    var isLate: Boolean,
+    //是否是枚举
+    var isEnum: Boolean
 ) {
 
     //待定


### PR DESCRIPTION
目标：
修改实体属性类型为枚举时，能正确生成对应的helper。

使用步骤：
1、启动组件，贴入json，定义类名，生成实体（此阶段不支持枚举引入）；
2、修改实体，引入枚举（例如把某个有限int转换成枚举）；
3、alt+j，重新生成；

已知问题：
目前只支持单个dart文件内定义的枚举及使用，跨dart文件定义的枚举未支持（主要不会kotlin），希望其他大神再改造下吧。