### PR TITLE
兼容json_annotation注解和json_serializable生成格式

### DIFF
--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/ClassGeneratorInfoModel.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/ClassGeneratorInfoModel.kt
@@ -2,6 +2,7 @@ package com.github.zhangruiyu.flutterjsonbeanfactory.action.dart_to_helper.node
 
 import com.github.zhangruiyu.flutterjsonbeanfactory.action.jsontodart.utils.*
 import com.github.zhangruiyu.flutterjsonbeanfactory.utils.toLowerCaseFirstOne
+import com.intellij.openapi.vfs.VirtualFile
 
 
 /**
@@ -10,11 +11,16 @@ import com.github.zhangruiyu.flutterjsonbeanfactory.utils.toLowerCaseFirstOne
  * Time: 11:32
  */
 class HelperFileGeneratorInfo(
+    val directory: VirtualFile?,
+    val name: String,
+    val partOf: String?,
     val imports: MutableList<String> = mutableListOf(),
     val classes: MutableList<HelperClassGeneratorInfo> = mutableListOf()
 )
 
-class HelperClassGeneratorInfo {
+class HelperClassGeneratorInfo(
+    private val isPrivate: Boolean = false,
+) {
     //协助的类名
     lateinit var className: String
     val fields: MutableList<Filed> = mutableListOf()
@@ -47,7 +53,7 @@ class HelperClassGeneratorInfo {
     private fun jsonParseFunc(): String {
         val sb = StringBuffer();
         sb.append("\n")
-        sb.append("$className \$${className}FromJson(Map<String, dynamic> json) {\n")
+        sb.append("$className ${"_".takeIf { isPrivate }.orEmpty()}\$${className}FromJson(Map<String, dynamic> json) {\n")
         val classInstanceName = className.toLowerCaseFirstOne()
         sb.append("\tfinal $className $classInstanceName = ${className}();\n")
         fields.forEach { k ->
@@ -103,7 +109,7 @@ class HelperClassGeneratorInfo {
     //生成tojson方法
     private fun jsonGenFunc(): String {
         val sb = StringBuffer();
-        sb.append("Map<String, dynamic> \$${className}ToJson(${className} entity) {\n");
+        sb.append("Map<String, dynamic> ${"_".takeIf { isPrivate }.orEmpty()}\$${className}ToJson(${className} entity) {\n");
         sb.append("\tfinal Map<String, dynamic> data = <String, dynamic>{};\n");
         fields.forEach { k ->
             //如果serialize不是false,那么就解析,否则不解析

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/GeneratorDartClassNodeToHelperInfo.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/GeneratorDartClassNodeToHelperInfo.kt
@@ -56,7 +56,7 @@ object GeneratorDartClassNodeToHelperInfo {
                                                     //@
                                                             annotationWholeNode.text == "@" &&
                                                             //JSONField
-                                                            fieldWholeNode.firstChildNode.treeNext.elementType == DartTokenTypes.REFERENCE_EXPRESSION && fieldWholeNode.firstChildNode.treeNext.text == "JSONField"
+                                                            fieldWholeNode.firstChildNode.treeNext.elementType == DartTokenTypes.REFERENCE_EXPRESSION && fieldWholeNode.firstChildNode.treeNext.text == if(isPrivate) "JsonKey" else "JSONField"
                                                     ) {
 
                                                         if (fieldWholeNode.firstChildNode.treeNext.treeNext.elementType == DartTokenTypes.ARGUMENTS) {

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/GeneratorDartClassNodeToHelperInfo.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/GeneratorDartClassNodeToHelperInfo.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.psi.psiUtil.children
 
 object GeneratorDartClassNodeToHelperInfo {
     val notSupportType = listOf("static", "const")
-    fun getDartFileHelperClassGeneratorInfo(file: PsiFile): HelperFileGeneratorInfo? {
+    fun getDartFileHelperClassGeneratorInfo(file: PsiFile, isPrivate: Boolean = false): HelperFileGeneratorInfo? {
         //不包含JsonConvert 那么就不转
         return if (file.text.contains("@JsonSerializable") && file.name != "json_convert_content.dart") {
             val mutableMapOf = mutableListOf<HelperClassGeneratorInfo>()
@@ -21,7 +21,7 @@ object GeneratorDartClassNodeToHelperInfo {
                 if (classNode?.elementType == DartTokenTypes.CLASS_DEFINITION && isJsonSerializable
                 ) {
                     if (classNode is CompositeElement) {
-                        val helperClassGeneratorInfo = HelperClassGeneratorInfo()
+                        val helperClassGeneratorInfo = HelperClassGeneratorInfo(isPrivate)
                         for (filedAndMethodNode in classNode.children()) {
                             val nodeName = filedAndMethodNode.text
                             //是类里字段
@@ -197,7 +197,13 @@ object GeneratorDartClassNodeToHelperInfo {
                  val toString33 = it?.lastChildNode?.toString()
             }*/
             }
-            if (mutableMapOf.isEmpty()) null else HelperFileGeneratorInfo(imports, mutableMapOf)
+            val name = file.name.removeSuffix(".dart")
+//            val parentPath = file.parent?.virtualFile?.path ?: ""
+//            val gPath = "$parentPath/$name.g.dart"
+            if (mutableMapOf.isEmpty()) null else HelperFileGeneratorInfo(
+                file.parent?.virtualFile, "$name.g.dart",
+                "part of '${file.name}';", imports, mutableMapOf
+            )
         } else null
     }
 }

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
@@ -5,7 +5,11 @@ import com.github.zhangruiyu.flutterjsonbeanfactory.action.jsontodart.utils.*
 import com.github.zhangruiyu.flutterjsonbeanfactory.setting.Settings
 import com.github.zhangruiyu.flutterjsonbeanfactory.utils.toUpperCaseFirstOne
 
-class ClassDefinition(private val name: String, private val privateFields: Boolean = false) {
+class ClassDefinition(
+    private val name: String,
+    private val privateFields: Boolean = false,
+    private val isPrivate: Boolean = false, // class
+) {
     val fields = mutableMapOf<String, TypeDefinition>()
     val dependencies: List<Dependency>
         get() {
@@ -92,9 +96,9 @@ $_fieldList
   
   ${name}();
 
-  factory ${name}.fromJson(Map<String, dynamic> json) => $${name}FromJson(json);
+  factory ${name}.fromJson(Map<String, dynamic> json) => ${"_".takeIf { isPrivate }.orEmpty()}$${name}FromJson(json);
 
-  Map<String, dynamic> toJson() => $${name}ToJson(this);
+  Map<String, dynamic> toJson() => ${"_".takeIf { isPrivate }.orEmpty()}$${name}ToJson(this);
 
   @override
   String toString() {

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
@@ -73,7 +73,7 @@ class ClassDefinition(
                 //如果驼峰命名后不一致,才这样
                 if (fieldName != key) {
                     sb.append('\t')
-                    sb.append("@JSONField(name: \"${key}\")\n")
+                    sb.append("@${if (isPrivate) "JsonKey" else "JSONField"}(name: \"${key}\")\n")
                 }
                 sb.append('\t')
                 _addTypeDef(f!!, sb, prefix, suffix)

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/utils/YamlHelper.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/utils/YamlHelper.kt
@@ -34,6 +34,15 @@ object YamlHelper {
     fun shouldActivateWith(pubSpecConfig: PubSpecConfig?): Boolean {
         return pubSpecConfig?.pubRoot?.declaresFlutter() ?: false
     }
+
+    @Suppress("DuplicatedCode")
+    @JvmStatic
+    fun hasLibJsonAnnotation(project: Project) = hasLibJsonAnnotation(getPubSpecConfig(project))
+
+    @Suppress("DuplicatedCode")
+    @JvmStatic
+    fun hasLibJsonAnnotation(pubSpecConfig: PubSpecConfig?) =
+        pubSpecConfig?.hasLibJsonAnnotation ?: false
 }
 
 
@@ -76,6 +85,8 @@ fun VirtualFile?.commitContent(project: Project, content: String) {
 private const val PROJECT_NAME = "name"
 private const val PUBSPEC_ENABLE_PLUGIN_KEY = "enable"
 private const val PUBSPEC_DART_ENABLED_KEY = "enable-for-dart"
+private const val PUBSPEC_DEPENDENCIES = "dependencies"
+private const val PUBSPEC_LIB_JSON_ANNOTATION = "json_annotation"
 
 data class PubSpecConfig(
     val project: Project,
@@ -85,5 +96,8 @@ data class PubSpecConfig(
     val name: String = ((if (map[PROJECT_NAME] == "null") null else map[PROJECT_NAME]) ?: project.name).toString(),
 //    val flutterJsonMap: Map<*, *>? = map[PUBSPEC_KEY] as? Map<*, *>,
     val isFlutterModule: Boolean = FlutterModuleUtils.hasFlutterModule(project),
+    // 是否依赖 json_annotation
+    val hasLibJsonAnnotation: Boolean = (map[PUBSPEC_DEPENDENCIES] as? Map<*, *>)
+        ?.containsKey(PUBSPEC_LIB_JSON_ANNOTATION) ?: false,
 //    val isEnabled: Boolean = isOptionTrue(flutterJsonMap, PUBSPEC_ENABLE_PLUGIN_KEY),
 )


### PR DESCRIPTION
判断 `pubspec.yaml` 是否添加依赖 `json_annotation` 没有采用原来生成方式，避免影响之前内容。
依赖了 `json_annotation` 则使用 `json_annotation` 库提供的 `@JsonSerializable` 注解，生成的目录和格式调整为 `json_serializable` 生成格式，主要区别在于采用 `part` 方式引入，隐藏了原来 `$` 开头的类文件名变成了 `_$` 对用户不可见避免失误导入，同时对于没用插件的用户可以使用 `json_serializable` 通过命令生成兼容格式。