### PR TITLE
生成文件格式化；添加yaml配置是否兼容json_serializable

### DIFF
--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/FlutterBeanFactoryAction.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/FlutterBeanFactoryAction.kt
@@ -25,6 +25,8 @@ class FlutterBeanFactoryAction : AnAction() {
     }
 
     companion object {
+
+        private val indent = FileHelpers.indent
         /**
          * 生成辅助类
          */
@@ -75,19 +77,19 @@ class FlutterBeanFactoryAction : AnAction() {
 
                         ////
                         content.append("JsonConvert jsonConvert = JsonConvert();")
-                        content.append("\n")
+                        content.append("\n\n")
                         content.append("typedef JsonConvertFunction<T> = T Function(Map<String, dynamic> json);")
                         content.append("\n\n")
                         content.append("class JsonConvert {")
                         content.append("\n")
-                        content.append("\tstatic final Map<String, JsonConvertFunction> _convertFuncMap = {")
+                        content.append("${indent}static final Map<String, JsonConvertFunction> _convertFuncMap = {")
                         content.append("\n")
                         allClass.forEach { itemClass ->
                             itemClass.first.classes.forEach { itemFile ->
-                                content.append("\t\t(${itemFile.className}).toString(): ${itemFile.className}.fromJson,\n")
+                                content.append("${indent}${indent}(${itemFile.className}).toString(): ${itemFile.className}.fromJson,\n")
                             }
                         }
-                        content.append("\t};")
+                        content.append("${indent}};")
                         content.append("\n\n")
                         content.append(
                             "  T? convert<T>(dynamic value) {\n" +
@@ -170,36 +172,37 @@ class FlutterBeanFactoryAction : AnAction() {
                         //_getListFromType
                         content.append("\n\n")
                         content.append(
-                            "\t//list is returned by type\n" +
-                                    "\tstatic M? _getListChildType<M>(List<Map<String, dynamic>> data) {\n"
+                            "${indent}//list is returned by type\n" +
+                                    "${indent}static M? _getListChildType<M>(List<Map<String, dynamic>> data) {\n"
                         )
                         allClass.forEach { itemClass ->
                             itemClass.first.classes.forEach { itemFile ->
-                                content.append("\t\tif(<${itemFile.className}>[] is M){\n")
-                                content.append("\t\t\treturn data.map<${itemFile.className}>((Map<String, dynamic> e) => ${itemFile.className}.fromJson(e)).toList() as M;\n")
-                                content.append("\t\t}\n")
+                                content.append("${indent}${indent}if(<${itemFile.className}>[] is M){\n")
+                                content.append("${indent}${indent}${indent}return data.map<${itemFile.className}>((Map<String, dynamic> e) => ${itemFile.className}.fromJson(e)).toList() as M;\n")
+                                content.append("${indent}${indent}}\n")
                             }
                         }
                         content.append(
-                            "\n\t\tdebugPrint(\"\${M.toString()} not found\");\n\t"
+                            "\n${indent}${indent}debugPrint(\"\${M.toString()} not found\");\n${indent}"
                         )
                         content.append(
-                            "\n\t\treturn null;\n}"
+                            "\n${indent}${indent}return null;\n}"
                         )
                         content.append("\n\n")
                         //fromJsonAsT
                         content.append(
-                            "\tstatic M? fromJsonAsT<M>(dynamic json) {\n" +
-                                    "\t\tif (json is List) {\n" +
-                                    "\t\t\treturn _getListChildType<M>(json.map((e) => e as Map<String, dynamic>).toList());\n" +
-                                    "\t\t} else {\n" +
-                                    "\t\t\treturn jsonConvert.asT<M>(json);\n" +
-                                    "\t\t}\n" +
-                                    "\t}"
+                            "${indent}static M? fromJsonAsT<M>(dynamic json) {\n" +
+                                    "${indent}${indent}if (json is List) {\n" +
+                                    "${indent}${indent}${indent}return _getListChildType<M>(json.map((e) => e as Map<String, dynamic>).toList());\n" +
+                                    "${indent}${indent}} else {\n" +
+                                    "${indent}${indent}${indent}return jsonConvert.asT<M>(json);\n" +
+                                    "${indent}${indent}}\n" +
+                                    "${indent}}"
                         )
 
                         content.append("\n")
                         content.append("}")
+                        content.append("\n")
                         val generated = FileHelpers.getJsonConvertBaseFile(project)
                         //获取json_convert_content目录,并写入
                         generated.findOrCreateChildData(this, "json_convert_content.dart")

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/ClassGeneratorInfoModel.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/node/ClassGeneratorInfoModel.kt
@@ -1,6 +1,7 @@
 package com.github.zhangruiyu.flutterjsonbeanfactory.action.dart_to_helper.node
 
 import com.github.zhangruiyu.flutterjsonbeanfactory.action.jsontodart.utils.*
+import com.github.zhangruiyu.flutterjsonbeanfactory.file.FileHelpers
 import com.github.zhangruiyu.flutterjsonbeanfactory.utils.toLowerCaseFirstOne
 import com.intellij.openapi.vfs.VirtualFile
 
@@ -24,6 +25,7 @@ class HelperClassGeneratorInfo(
     //协助的类名
     lateinit var className: String
     val fields: MutableList<Filed> = mutableListOf()
+    private val indent = FileHelpers.indent
 
 
     fun addFiled(type: String, name: String, isLate: Boolean, annotationValue: List<AnnotationValue>?) {
@@ -55,14 +57,14 @@ class HelperClassGeneratorInfo(
         sb.append("\n")
         sb.append("$className ${"_".takeIf { isPrivate }.orEmpty()}\$${className}FromJson(Map<String, dynamic> json) {\n")
         val classInstanceName = className.toLowerCaseFirstOne()
-        sb.append("\tfinal $className $classInstanceName = ${className}();\n")
+        sb.append("${indent}final $className $classInstanceName = ${className}();\n")
         fields.forEach { k ->
             //如果deserialize不是false,那么就解析,否则不解析
             if (k.getValueByName<Boolean>("deserialize") != false) {
-                sb.append("\t${jsonParseExpression(k, classInstanceName)}\n")
+                sb.append("${indent}${jsonParseExpression(k, classInstanceName)}\n")
             }
         }
-        sb.append("\treturn ${classInstanceName};\n")
+        sb.append("${indent}return ${classInstanceName};\n")
         sb.append("}")
         return sb.toString()
     }
@@ -99,10 +101,10 @@ class HelperClassGeneratorInfo(
         } else {
             stringBuilder.append("final ${type}? $classFieldName = jsonConvert.convert<${type}>(json['${getJsonName}']);\n")
         }
-        stringBuilder.append("\tif (${classFieldName} != null) {\n")
-        stringBuilder.append("\t\t${classInstanceName}.$classFieldName = $classFieldName;")
+        stringBuilder.append("${indent}if (${classFieldName} != null) {\n")
+        stringBuilder.append("${indent}${indent}${classInstanceName}.$classFieldName = $classFieldName;")
         stringBuilder.append("\n")
-        stringBuilder.append("\t}")
+        stringBuilder.append("${indent}}")
         return stringBuilder.toString()
     }
 
@@ -110,14 +112,14 @@ class HelperClassGeneratorInfo(
     private fun jsonGenFunc(): String {
         val sb = StringBuffer();
         sb.append("Map<String, dynamic> ${"_".takeIf { isPrivate }.orEmpty()}\$${className}ToJson(${className} entity) {\n");
-        sb.append("\tfinal Map<String, dynamic> data = <String, dynamic>{};\n");
+        sb.append("${indent}final Map<String, dynamic> data = <String, dynamic>{};\n");
         fields.forEach { k ->
             //如果serialize不是false,那么就解析,否则不解析
             if (k.getValueByName<Boolean>("serialize") != false) {
-                sb.append("\t${toJsonExpression(k)}\n")
+                sb.append("${indent}${toJsonExpression(k)}\n")
             }
         }
-        sb.append("\treturn data;\n");
+        sb.append("${indent}return data;\n");
         sb.append("}");
         return sb.toString()
 

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
@@ -2,6 +2,7 @@ package com.github.zhangruiyu.flutterjsonbeanfactory.action.jsontodart
 
 import com.intellij.openapi.components.ServiceManager
 import com.github.zhangruiyu.flutterjsonbeanfactory.action.jsontodart.utils.*
+import com.github.zhangruiyu.flutterjsonbeanfactory.file.FileHelpers
 import com.github.zhangruiyu.flutterjsonbeanfactory.setting.Settings
 import com.github.zhangruiyu.flutterjsonbeanfactory.utils.toUpperCaseFirstOne
 
@@ -62,6 +63,7 @@ class ClassDefinition(
     //字段的集合
     val _fieldList: String
         get() {
+            val indent = FileHelpers.indent
             val settings = ServiceManager.getService(Settings::class.java)
             val isOpenNullAble = settings.isOpenNullAble == true
             val prefix = if (!isOpenNullAble) "late " else ""
@@ -72,10 +74,10 @@ class ClassDefinition(
                 val sb = StringBuffer();
                 //如果驼峰命名后不一致,才这样
                 if (fieldName != key) {
-                    sb.append('\t')
+                    sb.append(indent)
                     sb.append("@${if (isPrivate) "JsonKey" else "JSONField"}(name: \"${key}\")\n")
                 }
-                sb.append('\t')
+                sb.append(indent)
                 _addTypeDef(f!!, sb, prefix, suffix)
                 sb.append(" $fieldName;")
                 return@map sb.toString()
@@ -91,9 +93,8 @@ class ClassDefinition(
             """
 @JsonSerializable()
 class $name {
-
 $_fieldList
-  
+
   ${name}();
 
   factory ${name}.fromJson(Map<String, dynamic> json) => ${"_".takeIf { isPrivate }.orEmpty()}$${name}FromJson(json);

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ModelGenerator.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ModelGenerator.kt
@@ -127,6 +127,7 @@ class ModelGenerator(
         stringBuilder.append("\n")
         stringBuilder.append("\n")
         stringBuilder.append(classContent)
+        stringBuilder.append("\n")
         //生成helper类
 
         //生成

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ModelGenerator.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ModelGenerator.kt
@@ -97,9 +97,11 @@ class ModelGenerator(
 //        val jsonRawData = gson.fromJson<Map<String, Any>>(collectInfo.userInputJson, HashMap::class.java)
         val pubSpecConfig = YamlHelper.getPubSpecConfig(project)
         val hasLibJsonAnnotation = pubSpecConfig?.hasLibJsonAnnotation ?: false
+        val isJsonSerializableCompat = pubSpecConfig?.isJsonSerializableCompat ?: false
+        val isCompat = hasLibJsonAnnotation && isJsonSerializableCompat
         val classContentList = generateClassDefinition(
             collectInfo.firstClassName(), "", JsonUtils.jsonMapMCompletion(jsonRawData)
-                ?: mutableMapOf<String, Any>(), isPrivate = hasLibJsonAnnotation
+                ?: mutableMapOf<String, Any>(), isPrivate = isCompat
         )
         val classContent = classContentList.joinToString("\n\n")
         classContentList.fold(mutableListOf<TypeDefinition>()) { acc, de ->
@@ -110,11 +112,12 @@ class ModelGenerator(
         //导包
         stringBuilder.append("import 'dart:convert';")
         stringBuilder.append("\n")
-        if(pubSpecConfig?.hasLibJsonAnnotation == true) {
+
+        if (isCompat) {
             stringBuilder.append("import 'package:json_annotation/json_annotation.dart';")
             stringBuilder.append("\n")
-            stringBuilder.append("import 'package:${pubSpecConfig.name}/generated/json/base/json_convert_content.dart';")
-            stringBuilder.append("\n")
+            stringBuilder.append("import 'package:${pubSpecConfig?.name}/generated/json/base/json_convert_content.dart';")
+            stringBuilder.append("\n\n")
             stringBuilder.append("part '${fileName}.g.dart';")
         } else {
             stringBuilder.append("import 'package:${pubSpecConfig?.name}/generated/json/base/json_field.dart';")

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/file/FileHelpers.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/file/FileHelpers.kt
@@ -124,7 +124,9 @@ object FileHelpers {
         //导包
         val pubSpecConfig = YamlHelper.getPubSpecConfig(project)
         val hasLibJsonAnnotation = pubSpecConfig?.hasLibJsonAnnotation ?: false
-        if (!hasLibJsonAnnotation) {
+        val isJsonSerializableCompat = pubSpecConfig?.isJsonSerializableCompat ?: false
+        val isCompat = hasLibJsonAnnotation && isJsonSerializableCompat
+        if (!isCompat) {
             //辅助主类的包名
             content.append("import 'package:${pubSpecConfig?.name}/generated/json/base/json_convert_content.dart';\n")
             content.append(packageName)
@@ -142,7 +144,7 @@ object FileHelpers {
         // 依赖 json_annotation 采用 part of 方式
         helperClassGeneratorInfos?.partOf?.takeIf { hasLibJsonAnnotation }?.also { partOf ->
             content.append(partOf)
-            content.append("\n\n")
+            content.append("\n")
         }
 
         helperClassGeneratorInfos?.imports?.takeIf { !hasLibJsonAnnotation }?.filterNot {
@@ -183,6 +185,8 @@ object FileHelpers {
     fun getAllEntityFiles(project: Project): List<Pair<HelperFileGeneratorInfo, String>> {
         val pubSpecConfig = getPubSpecConfig(project)
         val hasLibJsonAnnotation = pubSpecConfig?.hasLibJsonAnnotation ?: false
+        val isJsonSerializableCompat = pubSpecConfig?.isJsonSerializableCompat ?: false
+        val isCompat = hasLibJsonAnnotation && isJsonSerializableCompat
         val psiManager = PsiManager.getInstance(project)
         return FilenameIndex.getAllFilesByExt(project, "dart", GlobalSearchScope.projectScope(project)).filter {
             //不过滤entity结尾了
@@ -193,7 +197,7 @@ object FileHelpers {
             try {
                 val dartFileHelperClassGeneratorInfo =
                     GeneratorDartClassNodeToHelperInfo.getDartFileHelperClassGeneratorInfo(
-                        psiManager.findFile(it)!!, hasLibJsonAnnotation)
+                        psiManager.findFile(it)!!, isCompat)
                 //导包
                 if (dartFileHelperClassGeneratorInfo == null) {
                     null

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/file/FileHelpers.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/file/FileHelpers.kt
@@ -23,6 +23,8 @@ import java.io.File
 //import io.flutter.utils.FlutterModuleUtils
 
 object FileHelpers {
+    const val indent = "  "
+
     @JvmStatic
     fun getResourceFolder(project: Project): VirtualFile {
         val guessProjectDir = project.guessProjectDir()
@@ -156,6 +158,7 @@ object FileHelpers {
             content.append("\n\n")
         }
         content.append(helperClassGeneratorInfos?.classes?.joinToString("\n"))
+        content.append("\n")
         //创建文件
         if (hasLibJsonAnnotation && helperClassGeneratorInfos?.directory != null) {
             getDirectoryEntityHelperFile(

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/utils/YamlHelper.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/utils/YamlHelper.kt
@@ -1,4 +1,5 @@
 package com.github.zhangruiyu.flutterjsonbeanfactory.utils
+
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
@@ -50,8 +51,8 @@ object YamlHelper {
 /**
  * 如果没有配置,那么默认是true
  */
-private fun isOptionTrue(map: Map<*, *>?, name: String): Boolean {
-    val value = map?.get(name)?.toString()?.toLowerCase() ?: "true"
+private fun isOptionTrue(map: Map<*, *>?, name: String, default: Boolean = true): Boolean {
+    val value = map?.get(name)?.toString()?.toLowerCase() ?: return default
     return "true" == value
 }
 
@@ -87,6 +88,7 @@ private const val PUBSPEC_ENABLE_PLUGIN_KEY = "enable"
 private const val PUBSPEC_DART_ENABLED_KEY = "enable-for-dart"
 private const val PUBSPEC_DEPENDENCIES = "dependencies"
 private const val PUBSPEC_LIB_JSON_ANNOTATION = "json_annotation"
+private const val PUBSPEC_JSON_SERIALIZABLE_COMPAT = "json_serializable_compat"
 
 data class PubSpecConfig(
     val project: Project,
@@ -99,5 +101,7 @@ data class PubSpecConfig(
     // 是否依赖 json_annotation
     val hasLibJsonAnnotation: Boolean = (map[PUBSPEC_DEPENDENCIES] as? Map<*, *>)
         ?.containsKey(PUBSPEC_LIB_JSON_ANNOTATION) ?: false,
+    // 是否兼容 json_serializable
+    val isJsonSerializableCompat: Boolean = isOptionTrue(map, PUBSPEC_JSON_SERIALIZABLE_COMPAT, false),
 //    val isEnabled: Boolean = isOptionTrue(flutterJsonMap, PUBSPEC_ENABLE_PLUGIN_KEY),
 )


### PR DESCRIPTION
1. 生成文件原本空格和tab混用统一改为空格，样式小调整更接近` dart format`格式化结果。
2. 在 #114 基础上添加`pubspec.yaml`兼容配置`json_serializable_compat`为`true`才启用`json_serializable`兼容模式，没配置默认不启用。