### PR TITLE
[devin] FlutterBeanFactoryAction add ConvertExceptionHandler

### DIFF
--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/FlutterBeanFactoryAction.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/dart_to_helper/FlutterBeanFactoryAction.kt
@@ -76,8 +76,12 @@ class FlutterBeanFactoryAction : AnAction() {
                         content.append("typedef JsonConvertFunction<T> = T Function(Map<String, dynamic> json);")
                         content.append("\n")
                         content.append("typedef EnumConvertFunction<T> = T Function(String value);")
+                        content.append("\n")
+                        content.append("typedef ConvertExceptionHandler = void Function(Object error, StackTrace stackTrace);")
                         content.append("\n\n")
                         content.append("class JsonConvert {")
+                        content.append("\n")
+                        content.append("\tstatic ConvertExceptionHandler? onError;")
                         content.append("\n")
                         content.append("\tstatic Map<String, JsonConvertFunction> get convertFuncMap => {")
                         content.append("\n")
@@ -100,6 +104,9 @@ class FlutterBeanFactoryAction : AnAction() {
                                     "      return _asT<T>(value, enumConvert: enumConvert);\n" +
                                     "    } catch (e, stackTrace) {\n" +
                                     "      debugPrint('asT<${"\$T"}> ${"\$e"} ${"\$stackTrace"}');\n" +
+                                    "      if (onError != null) {" +
+                                    "         onError!(e, stackTrace);" +
+                                    "      }"+
                                     "      return null;\n" +
                                     "    }\n" +
                                     "  }"
@@ -114,6 +121,9 @@ class FlutterBeanFactoryAction : AnAction() {
                                     "      return value.map((dynamic e) => _asT<T>(e,enumConvert: enumConvert)).toList();\n" +
                                     "    } catch (e, stackTrace) {\n" +
                                     "      debugPrint('asT<${"\$T"}> ${"\$e"} ${"\$stackTrace"}');\n" +
+                                    "      if (onError != null) {" +
+                                    "         onError!(e, stackTrace);" +
+                                    "      }"+
                                     "      return <T>[];\n" +
                                     "    }\n" +
                                     "  }"
@@ -128,6 +138,9 @@ class FlutterBeanFactoryAction : AnAction() {
                                     "      return (value as List<dynamic>).map((dynamic e) => _asT<T>(e,enumConvert: enumConvert)!).toList();\n" +
                                     "    } catch (e, stackTrace) {\n" +
                                     "      debugPrint('asT<${"\$T"}> ${"\$e"} ${"\$stackTrace"}');\n" +
+                                    "      if (onError != null) {" +
+                                    "         onError!(e, stackTrace);" +
+                                    "      }"+
                                     "      return <T>[];\n" +
                                     "    }\n" +
                                     "  }"


### PR DESCRIPTION
作者大佬你好，我们在使用FlutterJsonBeanFactory的时候，发现转换失败的Exception已经被插件自己捕获，我们希望可以添加一个方法来让我们可以获取到异常的信息。麻烦你review一下，看能不能这样修改。
<img width="772" alt="image" src="https://github.com/fluttercandies/FlutterJsonBeanFactory/assets/24282000/1ac98918-4252-49d8-9c1d-c9d5939edd49">
<img width="751" alt="image" src="https://github.com/fluttercandies/FlutterJsonBeanFactory/assets/24282000/4e91ce25-aff6-4311-b1b8-6a8576973863">
