### PR TITLE
feat: Add support for double default values

### DIFF
--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/action/jsontodart/ClassDefinition.kt
@@ -118,10 +118,12 @@ class ClassDefinition(private val name: String, private val privateFields: Boole
                     } else if (f.subtype == null) {
                         if (f.name == "String" && settings.stringFieldDefaultValue()?.isNotEmpty() == true) {
                             sb.append(" = ${settings.stringFieldDefaultValue()}")
-                        } else if (f.name == "bool" && settings.stringFieldDefaultValue()?.isNotEmpty() == true) {
+                        } else if (f.name == "bool" && settings.boolFieldDefaultValue()?.isNotEmpty() == true) {
                             sb.append(" = ${settings.boolFieldDefaultValue()}")
-                        } else if (f.name == "int" && settings.stringFieldDefaultValue()?.isNotEmpty() == true) {
+                        } else if (f.name == "int" && settings.intFieldDefaultValue()?.isNotEmpty() == true) {
                             sb.append(" = ${settings.intFieldDefaultValue()}")
+                        } else if (f.name == "double" && settings.doubleFieldDefaultValue()?.isNotEmpty() == true) {
+                            sb.append(" = ${settings.doubleFieldDefaultValue()}")
                         }
                     }
                 }

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/setting/Settings.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/setting/Settings.kt
@@ -13,6 +13,7 @@ data class Settings(
     var boolDefaultValue: String = "false",
     var stringDefaultValue: String = "''",
     var intDefaultValue: String = "0",
+    var doubleDefaultValue: String = "0.0",
     var listDefaultValue: String = "[]",
 ) : PersistentStateComponent<Settings> {
 
@@ -47,6 +48,14 @@ data class Settings(
     fun intFieldDefaultValue(): String? {
         return if (setDefault == true && intDefaultValue.isNotEmpty()) {
             intDefaultValue
+        } else {
+            null
+        }
+    }
+
+    fun doubleFieldDefaultValue(): String? {
+        return if (setDefault == true && doubleDefaultValue.isNotEmpty()) {
+            doubleDefaultValue
         } else {
             null
         }

--- a/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/ui/JsonInputDialog.kt
+++ b/src/main/kotlin/com/github/zhangruiyu/flutterjsonbeanfactory/ui/JsonInputDialog.kt
@@ -173,6 +173,11 @@ open class JsonInputDialog(
         }, settings.intDefaultValue).forEach {
             defaultContainer.add(it)
         }
+        buildDefaultItem("double", { newText ->
+            settings.doubleDefaultValue = newText
+        }, settings.doubleDefaultValue).forEach {
+            defaultContainer.add(it)
+        }
         buildDefaultItem("bool", { newText ->
             settings.boolDefaultValue = newText
         }, settings.boolDefaultValue).forEach {


### PR DESCRIPTION
## 🐛 Problem
When using the "set default values" option, `double` fields were not getting default values assigned, causing inconsistent behavior compared to other primitive types (`int`, `bool`, `String`, `List`).

This could lead to:
- Runtime issues in Dart when double fields are not nullable
- Inconsistent code generation
- Missing default values for double properties

## ✅ Solution
Added complete support for `double` default values across the entire codebase:

### Changes Made:
1. **Settings.kt**: 
   - Added `doubleDefaultValue: String = "0.0"` field
   - Added `doubleFieldDefaultValue(): String?` method

2. **ClassDefinition.kt**: 
   - Added `double` case in field generation logic
   - **Bonus fix**: Fixed existing bugs where `bool` and `int` checks incorrectly used `stringFieldDefaultValue()`

3. **JsonInputDialog.kt**: 
   - Added UI input field for double default values
   - Positioned logically between `int` and `bool` fields

## 🧪 Testing
- [x] All files compile without errors
- [x] UI properly displays double default value input field
- [x] Generated code includes double default values when enabled
- [x] Existing functionality for other types remains unchanged

## 📸 Before vs After
**Before**: `double` fields had no default values
**After**: `double` fields get configurable default values (default: "0.0")

## 🔗 Related Issues
Fixes the missing double default value support identified during codebase analysis.